### PR TITLE
refactor: rework internal logic a little, etc

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,10 @@ module.exports = function(content, filename, context) {
     }
 
     var sandbox;
-    sandbox = _commonjsEval(content, filename, context);
+    // Skip commonjs evaluation if there are no `exports` or `module` occurrencies
+    if(/\b(exports|module)\b/.test(content)) {
+        sandbox = _commonjsEval(content, filename, context);
+    }
 
     var result;
     if(sandbox && !sandbox.__result) {

--- a/test/test.js
+++ b/test/test.js
@@ -12,7 +12,13 @@ describe('expression', () => {
 
     it('should eval expression', () => coco('({42:42})').eql({42: 42}));
 
+    it('should eval arrayExpression', () => coco('[{42:42}]').eql([{42: 42}]));
+
     it('should not eval simple object', () => coco('{}').to.undefined);
+
+    it('should eval expression with \'exports\' key', () => coco('[{exports:42}]').eql([{exports: 42}]));
+
+    it('should eval expression with \'module\' key', () => coco('[{module:42}]').eql([{module: 42}]));
 });
 
 describe('commonJS modules', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -114,4 +114,14 @@ describe('errors', () => {
 
         expect(() => nodeEval(content, path)).to.throw(/Unexpected token !/);
     });
+
+    it('should throw error on require call without filename', function() {
+        expect(() => nodeEval('exports.path = require("path");'))
+            .to.throw(/pass in filename/);
+    });
+
+    it('should throw error on require call without filename', function() {
+        expect(() => nodeEval('exports.path = require.resolve("path");'))
+            .to.throw(/pass in filename/);
+    });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -4,7 +4,7 @@ var expect = chai.expect;
 var nodeEval = require('../');
 
 function coco(content, context) {
-    return expect(nodeEval(content, 'file.js', context)).to;
+    return expect(nodeEval(content, '/file.js', context)).to;
 }
 
 describe('expression', () => {
@@ -48,7 +48,7 @@ describe('commonJS modules', () => {
                 block: p.name,
             };
         `;
-        coco(requireContent).eql({block: 'node-eval'});
+        expect(nodeEval(requireContent, 'file.js')).to.eql({block: 'node-eval'});
     });
 
     it('should require relatively passed modules', function() {


### PR DESCRIPTION
- make commonjs function with sandbox as a result
- skip resolving filename to previous if not passed
- throw an error if require or r.resolve used without filename
- skip evaluating commonjs if no need

cc @blond @yeti-or

This prevents double evaluations for the most non-CommonJS cases
